### PR TITLE
add userid input and remove sidebar-header

### DIFF
--- a/assets/js/platformer3x/SettingsControl.js
+++ b/assets/js/platformer3x/SettingsControl.js
@@ -622,6 +622,10 @@ export class SettingsControl extends LocalStorage{
        hintsSection.append(hintsButton)
        document.getElementById("sidebar").append(hintsSection)
 
+       // Get/Construct HTML input and event update fo game speed
+       var userID = settingsControl.userIDInput;
+       document.getElementById("sidebar").append(userID);
+
        // Get/Construct HTML input and event update for game speed 
        var gameSpeed = settingsControl.gameSpeedInput;
        document.getElementById("sidebar").append(gameSpeed);
@@ -669,8 +673,6 @@ export class SettingsControl extends LocalStorage{
         }
         // settings-button and event listener opens sidebar
         document.getElementById("settings-button").addEventListener("click",sidebarPanel);
-        // sidebar-header and event listener closes sidebar
-        document.getElementById("sidebar-header").addEventListener("click",sidebarPanel);
 
         window.addEventListener('load', function() {
             var submenu = document.querySelector('.submenu');

--- a/index.md
+++ b/index.md
@@ -9,7 +9,6 @@ image: /images/platformer/backgrounds/home.png
 
 <!-- DOM Settings Panel (sidebar id and div), managed by SettingsContro.js -->
 <div id="sidebar" class="sidebar" style="z-index: 9999">
-    <a href="javascript:void(0)" id="sidebar-header">&times; Settings</a>
   </div>
   <div id="leaderboardDropDown" class="leaderboardDropDown" style="z-index: 9999">
     <!-- <a href="javascript:void(0)" id="leaderboard-header">&times; Leaderboard</a> -->


### PR DESCRIPTION
## Add userID
- Adding userID was pretty straightforward since I just needed to initialize the variable in `settingsControl.js`

```js
       // Get/Construct HTML input and event update fo game speed
       var userID = settingsControl.userIDInput;
       document.getElementById("sidebar").append(userID);
```

## Remove sidebar-header
- To remove the sidebar-header and make the click away feature more functional in the settings menu, I just needed to remove the div element from `index.md` and get rid of the nonfunctional event listener in `settingsControl.js`